### PR TITLE
fix: throws error when eyecheck failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ class ApplitoolsHelper extends Helper {
         }
 
         await eyes.closeAsync();
+        return eyes.getResults();
     }
 }
 


### PR DESCRIPTION
Resolves #9 
Currently, when the eyecheck failed, we didn't throw any error. Now we add this verification step.

```
-- FAILURES:

  1) Applitools functionality
       Check home page @test:
     Test 'Homepage' of 'Application Under Test' detected differences! See details at: https://eyes.applitools.com/app/batches/xxxxxxxxx?accountId=xxxxxxxx
      at Eyes.getResults (node_modules/@applitools/eyes/dist/Eyes.js:426:27)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Test.<anonymous> (applitools_test.js:9:5)
  
  Scenario Steps:
  - I.eyeCheck({"pageName":"Homepage"}) at Test.<anonymous> (./applitools_test.js:9:13)
  - I.amOnPage("https://codecept.io") at Test.<anonymous> (./applitools_test.js:8:7)
  - I.eyeCheck({"pageName":"Homepage"}) at Test.<anonymous> (./applitools_test.js:7:13)
  - I.amOnPage("https://applitools.com/helloworld") at Test.<anonymous> (./applitools_test.js:6:7)
  
  Artifacts:
  - screenshot: /Users/t/Desktop/projects/applitools-example/output/Check_home_page_@test.failed.png


  FAIL  | 0 passed, 1 failed   // 36s
```
